### PR TITLE
PHG-381: proxy panther tree/MSA S3 fetches through API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ error.log
 logfile.log
 uncaughtexceptions.log
 ecosystem.config.js
+ecosystem.config.server.js

--- a/config/default.json
+++ b/config/default.json
@@ -6,5 +6,9 @@
   "user": "solr_user",
   "password": "solr_password",
   "treeS3Url": "https://phg-panther-data-19.s3-us-west-2.amazonaws.com/",
-  "msaS3Url": "https://phg-panther-msa-data-19.s3-us-west-2.amazonaws.com/"
+  "msaS3Url": "https://phg-panther-msa-data-19.s3-us-west-2.amazonaws.com/",
+  "orthologsS3Url": "https://phg-orthologs-17.s3-us-west-2.amazonaws.com/",
+  "paralogsS3Url": "https://phg-paralogs-17.s3-us-west-2.amazonaws.com/",
+  "orthologsDownloadS3Url": "https://phg-orthologs-download-17.s3-us-west-2.amazonaws.com/",
+  "paralogsDownloadS3Url": "https://phg-paralogs-download-17.s3-us-west-2.amazonaws.com/"
 }

--- a/config/default.json
+++ b/config/default.json
@@ -1,8 +1,10 @@
 {
-    "host": "localhost",
-    "port": "8983",
-    "core": "panther",
-    "protocol": "http",
-    "user": "solr_user",
-    "password": "solr_password"
+  "host": "54.68.67.235",
+  "port": "8983",
+  "core": "panther",
+  "protocol": "http",
+  "user": "solr_user",
+  "password": "solr_password",
+  "treeS3Url": "https://phg-panther-data-19.s3-us-west-2.amazonaws.com/",
+  "msaS3Url": "https://phg-panther-msa-data-19.s3-us-west-2.amazonaws.com/"
 }

--- a/config/default.json
+++ b/config/default.json
@@ -1,5 +1,5 @@
 {
-  "host": "54.68.67.235",
+  "host": "localhost",
   "port": "8983",
   "core": "panther",
   "protocol": "http",

--- a/models/panther.js
+++ b/models/panther.js
@@ -13,6 +13,10 @@ const treeInputSchema = Joi.object().keys({
   id: Joi.string().regex(/^PTHR[0-9]{5,}$/).error(err=>{return {message: 'Invalid tree id'}}),
 });
 
+const agiInputSchema = Joi.object().keys({
+  id: Joi.string().regex(/^AT[1-5CM]G\d{5}$/).error(err=>{return {message: 'Invalid AGI locus id'}}),
+});
+
 function validateSearchInput(queryObj) {
   return Joi.validate(queryObj, searchInputSchema);
 }
@@ -21,7 +25,12 @@ function validateTreeInput(queryObj){
   return Joi.validate(queryObj, treeInputSchema);
 }
 
+function validateAgiInput(queryObj){
+  return Joi.validate(queryObj, agiInputSchema);
+}
+
 module.exports= {
   validateSearchInput,
   validateTreeInput,
+  validateAgiInput,
 }

--- a/routes/panther.js
+++ b/routes/panther.js
@@ -1,9 +1,30 @@
 const devDebugger = require('debug')('dev');
+const https = require('https');
+const config = require('config');
 const client = require('../startup/solr');
 const { buildFieldQuery, buildGeneralQuery, buildFacetQuery } = require('../common/query');
 const { validateSearchInput, validateTreeInput } = require('../models/panther');
 const express = require('express');
 const router = express.Router();
+
+const TREE_S3_BASE = config.get('treeS3Url');
+const MSA_S3_BASE = config.get('msaS3Url');
+
+function pipeS3Json(url, res) {
+    https.get(url, (s3) => {
+        if (s3.statusCode !== 200) {
+            res.status(s3.statusCode).send({ error: `upstream ${s3.statusCode}` });
+            s3.resume();
+            return;
+        }
+        res.setHeader('Content-Type', 'application/json');
+        res.setHeader('Cache-Control', 'public, max-age=86400');
+        s3.pipe(res);
+    }).on('error', (err) => {
+        devDebugger('S3 proxy error: ', err.message);
+        res.status(502).send({ error: err.message });
+    });
+}
 
 client.options.core = 'panther';
 devDebugger('client: \n', client.options);
@@ -73,6 +94,20 @@ router.get('/msa/:id', async (req, res) => {
     const query = client.query().q(req.params).start(0).rows(1).fl('msa_data');
     const result = await client.search(query);
     return res.status(200).send(result);
+});
+
+// proxy panther tree JSON from S3 (avoids browser CORS on the bucket)
+router.get('/tree-data/:id', (req, res) => {
+    const { error } = validateTreeInput(req.params);
+    if (error) return res.status(400).send(error.details[0].message);
+    pipeS3Json(`${TREE_S3_BASE}${req.params.id}.json`, res);
+});
+
+// proxy panther MSA JSON from S3 (avoids browser CORS on the bucket)
+router.get('/msa-data/:id', (req, res) => {
+    const { error } = validateTreeInput(req.params);
+    if (error) return res.status(400).send(error.details[0].message);
+    pipeS3Json(`${MSA_S3_BASE}${req.params.id}.json`, res);
 });
 
 module.exports = router;

--- a/routes/panther.js
+++ b/routes/panther.js
@@ -17,6 +17,8 @@ const PARALOGS_DL_S3_BASE = config.get('paralogsDownloadS3Url');
 function pipeS3(url, res, contentType) {
     const fail = (err) => {
         if (res.headersSent) { res.destroy(err); return; }
+        // strip the success-path Cache-Control so an error response isn't cached for 24h
+        res.removeHeader('Cache-Control');
         res.status(502).send({ error: err.message });
     };
     https.get(url, (s3) => {

--- a/routes/panther.js
+++ b/routes/panther.js
@@ -3,14 +3,18 @@ const https = require('https');
 const config = require('config');
 const client = require('../startup/solr');
 const { buildFieldQuery, buildGeneralQuery, buildFacetQuery } = require('../common/query');
-const { validateSearchInput, validateTreeInput } = require('../models/panther');
+const { validateSearchInput, validateTreeInput, validateAgiInput } = require('../models/panther');
 const express = require('express');
 const router = express.Router();
 
 const TREE_S3_BASE = config.get('treeS3Url');
 const MSA_S3_BASE = config.get('msaS3Url');
+const ORTHOLOGS_S3_BASE = config.get('orthologsS3Url');
+const PARALOGS_S3_BASE = config.get('paralogsS3Url');
+const ORTHOLOGS_DL_S3_BASE = config.get('orthologsDownloadS3Url');
+const PARALOGS_DL_S3_BASE = config.get('paralogsDownloadS3Url');
 
-function pipeS3Json(url, res) {
+function pipeS3(url, res, contentType) {
     const fail = (err) => {
         if (res.headersSent) { res.destroy(err); return; }
         res.status(502).send({ error: err.message });
@@ -22,7 +26,7 @@ function pipeS3Json(url, res) {
             return;
         }
         s3.on('error', (err) => { devDebugger('S3 stream error: ', err.message); fail(err); });
-        res.setHeader('Content-Type', 'application/json');
+        res.setHeader('Content-Type', contentType);
         res.setHeader('Cache-Control', 'public, max-age=86400');
         s3.pipe(res);
     }).on('error', (err) => { devDebugger('S3 proxy error: ', err.message); fail(err); });
@@ -102,14 +106,42 @@ router.get('/msa/:id', async (req, res) => {
 router.get('/tree-data/:id', (req, res) => {
     const { error } = validateTreeInput(req.params);
     if (error) return res.status(400).send(error.details[0].message);
-    pipeS3Json(`${TREE_S3_BASE}${req.params.id}.json`, res);
+    pipeS3(`${TREE_S3_BASE}${req.params.id}.json`, res, 'application/json');
 });
 
 // proxy panther MSA JSON from S3 (avoids browser CORS on the bucket)
 router.get('/msa-data/:id', (req, res) => {
     const { error } = validateTreeInput(req.params);
     if (error) return res.status(400).send(error.details[0].message);
-    pipeS3Json(`${MSA_S3_BASE}${req.params.id}.json`, res);
+    pipeS3(`${MSA_S3_BASE}${req.params.id}.json`, res, 'application/json');
+});
+
+// proxy ortholog JSON for a TAIR locus (avoids browser CORS on the bucket)
+router.get('/orthologs/:id', (req, res) => {
+    const { error } = validateAgiInput(req.params);
+    if (error) return res.status(400).send(error.details[0].message);
+    pipeS3(`${ORTHOLOGS_S3_BASE}${req.params.id}.json`, res, 'application/json');
+});
+
+// proxy paralog JSON for a TAIR locus
+router.get('/paralogs/:id', (req, res) => {
+    const { error } = validateAgiInput(req.params);
+    if (error) return res.status(400).send(error.details[0].message);
+    pipeS3(`${PARALOGS_S3_BASE}${req.params.id}.json`, res, 'application/json');
+});
+
+// proxy ortholog .txt download for a TAIR locus
+router.get('/orthologs-download/:id', (req, res) => {
+    const { error } = validateAgiInput(req.params);
+    if (error) return res.status(400).send(error.details[0].message);
+    pipeS3(`${ORTHOLOGS_DL_S3_BASE}${req.params.id}_ortholog.txt`, res, 'text/plain');
+});
+
+// proxy paralog .txt download for a TAIR locus
+router.get('/paralogs-download/:id', (req, res) => {
+    const { error } = validateAgiInput(req.params);
+    if (error) return res.status(400).send(error.details[0].message);
+    pipeS3(`${PARALOGS_DL_S3_BASE}${req.params.id}_paralog.txt`, res, 'text/plain');
 });
 
 module.exports = router;

--- a/routes/panther.js
+++ b/routes/panther.js
@@ -11,19 +11,21 @@ const TREE_S3_BASE = config.get('treeS3Url');
 const MSA_S3_BASE = config.get('msaS3Url');
 
 function pipeS3Json(url, res) {
+    const fail = (err) => {
+        if (res.headersSent) { res.destroy(err); return; }
+        res.status(502).send({ error: err.message });
+    };
     https.get(url, (s3) => {
         if (s3.statusCode !== 200) {
             res.status(s3.statusCode).send({ error: `upstream ${s3.statusCode}` });
             s3.resume();
             return;
         }
+        s3.on('error', (err) => { devDebugger('S3 stream error: ', err.message); fail(err); });
         res.setHeader('Content-Type', 'application/json');
         res.setHeader('Cache-Control', 'public, max-age=86400');
         s3.pipe(res);
-    }).on('error', (err) => {
-        devDebugger('S3 proxy error: ', err.message);
-        res.status(502).send({ error: err.message });
-    });
+    }).on('error', (err) => { devDebugger('S3 proxy error: ', err.message); fail(err); });
 }
 
 client.options.core = 'panther';


### PR DESCRIPTION
## Summary
- Adds `GET /api/panther/tree-data/:id` and `GET /api/panther/msa-data/:id` — streams JSON from the panther data and MSA S3 buckets so the browser doesn't hit them directly (CORS-blocked).
- Bucket URLs (`treeS3Url`, `msaS3Url`) are now `config`-driven, so the version-suffix bump (`-19` → `-20`) is a config change, not a code edit.
- Sets `Cache-Control: public, max-age=86400` on the proxied response so we don't turn a once-per-page S3 hit into a once-per-page API-then-S3 hit.
- Reuses `validateTreeInput` (`^PTHR[0-9]{5,}$`) on the `:id` param to block path injection.

## Linked
- https://phoenixbioinformatics.atlassian.net/browse/PHG-381

## Test plan
- [ ] On UAT, hit `GET /api/panther/tree-data/PTHR10000` → 200, JSON body matches `https://phg-panther-data-19.s3-us-west-2.amazonaws.com/PTHR10000.json`
- [ ] On UAT, hit `GET /api/panther/msa-data/PTHR10000` → 200, JSON body matches `https://phg-panther-msa-data-19.s3-us-west-2.amazonaws.com/PTHR10000.json`
- [ ] Bad id (e.g. `PTHR10`, `../foo`) → 400 "Invalid tree id"
- [ ] Verify `Cache-Control: public, max-age=86400` on the response headers
- [ ] Paired UI PR: tair/phylogenes-ui PHG-381 branch loads tree + MSA panels for a real family

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new API endpoints that proxy and stream external S3 content through the server, which can impact availability/performance and error handling if upstream responses change.
> 
> **Overview**
> Adds several new `GET /api/panther/*` endpoints that **proxy Panther/TAIR JSON and text downloads from S3 via the API** (tree, MSA, orthologs/paralogs, and their `.txt` downloads), streaming the upstream response to clients.
> 
> Introduces a shared `pipeS3` helper with `Cache-Control: public, max-age=86400` on success and basic upstream/error handling, and adds Joi validation for AGI locus IDs (`validateAgiInput`). S3 bucket base URLs are moved to `config/default.json`, and `ecosystem.config.server.js` is added to `.gitignore`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea392a631b9265b3f07e4875d932dac4ee14bf44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->